### PR TITLE
Remove workout ID from user messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -1632,7 +1632,6 @@ class FitnessBot:
 
             await message.answer(
                 f"💪 Тренировка начата!\n"
-                f"🆔 ID: {workout_id}\n"
                 f"⏰ Время начала: {datetime.now().strftime('%H:%M')}\n\n"
                 "📝 Добавляйте подходы командой /add или просто отправьте сообщение:\n"
                 "• Жим лёжа 60 кг 5 подходов по 8 раз\n"
@@ -2836,7 +2835,6 @@ class FitnessBot:
 
             await callback_query.message.edit_text(
                 f"💪 Тренировка начата!\n"
-                f"🆔 ID: {workout_id}\n"
                 f"⏰ Время начала: {datetime.now().strftime('%H:%M')}\n\n"
                 "📝 Добавляйте подходы командой /add или просто отправьте сообщение:\n"
                 "• Жим лёжа 60 кг 5 подходов по 8 раз\n"


### PR DESCRIPTION
## Summary
- Drop workout ID line from /train responses
- Keep workout ID logging for debugging only

## Testing
- `pytest -q` *(fails: No valid Google service account credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bce075b0832c9c070366960a5511